### PR TITLE
io: handle spaces in individual command line arguments

### DIFF
--- a/getphylo/ext/diamond.py
+++ b/getphylo/ext/diamond.py
@@ -18,12 +18,14 @@ def make_diamond_database(filename: str, dmnd_database=None, diamond_location='d
             None
     '''
     if dmnd_database is None:
-        database = " --db " + filename.split('.')[0] + ".dmnd"
+        database = filename.split('.')[0] + ".dmnd"
     else:
-        database = " --db " + dmnd_database
-    makedb = " makedb"
-    input_ = " --in " + filename + ""
-    command = diamond_location + makedb + database + input_
+        database = dmnd_database
+    command = [
+        diamond_location, "makedb",
+        "--db", database,
+        "--in", filename,
+    ]
     logging.debug(command)
     io.run_in_command_line(command)
 
@@ -40,17 +42,19 @@ def run_diamond_search(
             None
     '''
     if dmnd_database is None:
-        database = " --db " + filename.split('.')[0] + ".dmnd"
+        database = filename.split('.')[0] + ".dmnd"
     else:
-        database = " --db " + dmnd_database
+        database = dmnd_database
     if outname is None:
-        output = " --out " + dmnd_database.split('.')[0] + ".tsv"
+        output = dmnd_database.split('.')[0] + ".tsv"
     else:
-        output = " --out " + outname
-    diamond = diamond_location
-    blastp = " blastp"
-    query = " --query " + filename
-    outfmt = " --outfmt 6 qseqid sseqid pident"
-    command = diamond + blastp + database + query + output + outfmt
+        output = outname
+    command = [
+        diamond_location, "blastp",
+        "--query", filename,
+        "--db", database,
+        "--out", output,
+        "--outfmt", "6", "qseqid", "sseqid", "pident",
+    ]
     logging.debug(command)
     io.run_in_command_line(command)

--- a/getphylo/ext/fasttree.py
+++ b/getphylo/ext/fasttree.py
@@ -18,8 +18,11 @@ def run_fasttree(filename, outfile=None, fasttree_location='fasttree') -> None:
     '''
 
     if outfile is None:
-        out = " -out " + io.change_extension(filename, "tree") + " "
+        out = io.change_extension(filename, "tree")
     else:
-        out = " -out " + outfile + " "
-    command = fasttree_location
-    io.run_in_command_line(command + out + filename)
+        out = outfile
+    io.run_in_command_line([
+        fasttree_location,
+        "-out", out,
+        filename,
+    ])

--- a/getphylo/ext/iqtree.py
+++ b/getphylo/ext/iqtree.py
@@ -27,8 +27,6 @@ def run_iqtree(
     #do a run with or without partition file
     if partition_path is not None:
         partition = " ".join(['-spp', partition_path])
-        io.run_in_command_line(
-            " ".join([command, alignment, partition, out_path, model, bootstraps])
-            )
+        io.run_in_command_line([command, alignment, partition, out_path, model, bootstraps])
     else:
-        io.run_in_command_line(" ".join([command, alignment, out_path, model, bootstraps]))
+        io.run_in_command_line([command, alignment, out_path, model, bootstraps])

--- a/getphylo/ext/muscle.py
+++ b/getphylo/ext/muscle.py
@@ -60,5 +60,4 @@ def run_muscle(filename: str, outname=None, muscle_location: str = 'muscle') -> 
         args.extend(["-align", filename, "-output", outname])
     else:
         args.extend(["-in", filename, "-out", outname])
-    command = " ".join(args)
-    io.run_in_command_line(command)
+    io.run_in_command_line(args)

--- a/getphylo/utils/io.py
+++ b/getphylo/utils/io.py
@@ -9,7 +9,7 @@ Functions:
     make_folder(name: str) -> None
     read_file(filename: str) -> List[str]
     read_tsv(filename: str) -> List[str]
-    run_in_command_line(command: str)
+    run_in_command_line(command: Union[str, list[str])
     run_in_parallel(function: Callable, args_list: Iterable[List], cpus: int) -> List
     write_to_file(filename: str, write_lines: List[str]) -> None
 '''
@@ -117,15 +117,15 @@ def read_tsv(filename: str) -> List[str]:
             contents.append(line)
     return contents
 
-def run_in_command_line(command: str):
+def run_in_command_line(command: list[str]):
     '''
     Convert a string into a command and run in the terminal.
         Aruments:
-            command: string containing the command for the terminal
+            command: a list of strings, one for each command line argument
         Returns:
             process: the process being run
     '''
-    command = command.split(" ")
+    assert isinstance(command, list)
     logging.debug(command)
     try:
         with subprocess.Popen(


### PR DESCRIPTION
Fixes #3 by forcing `io.run_in_command_line` to take an argument list, which then respects however much whitespace is in the paths.